### PR TITLE
v2 dependent packages

### DIFF
--- a/src/UoN.AspNetCore.VersionMiddleware/UoN.AspNetCore.VersionMiddleware.csproj
+++ b/src/UoN.AspNetCore.VersionMiddleware/UoN.AspNetCore.VersionMiddleware.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-        <Version>2.0.0-beta.1</Version>
+        <Version>2.0.0</Version>
         <Nullable>enable</Nullable>
 
         <Authors>UoN Digital Research Service</Authors>
@@ -54,7 +54,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="UoN.VersionInformation" Version="2.0.0-beta.2" />
+        <PackageReference Include="UoN.VersionInformation" Version="2.0.0" />
     </ItemGroup>
 
     <!-- For development -->

--- a/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
+++ b/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>2.0.0-beta.1</Version>
+        <Version>2.0.0</Version>
 
         <Authors>UoN Digital Research Service</Authors>
 
@@ -44,7 +44,7 @@ This release is mostly for branding and versioning consistency due to updates to
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageReference Include="UoN.VersionInformation" Version="2.0.0-beta.2" />
+        <PackageReference Include="UoN.VersionInformation" Version="2.0.0" />
     </ItemGroup>
 
     <!-- For development -->


### PR DESCRIPTION
This PR updates the dependent packages (`UoN.AspNetCore.VersionMiddleware`, `UoN.VersionInformation.DependencyInjection`) to `v2.0.0`, and updates their own base package dependency to `UoN.VersionInformation` `v2.0.0`.